### PR TITLE
fix: case sensitive filename issue

### DIFF
--- a/src/bluevga.cpp
+++ b/src/bluevga.cpp
@@ -26,7 +26,7 @@
 
 */
 
-#include <arduino.h>
+#include <Arduino.h>
 #include "bluevga.h"
 #include "bluevgadriver.h"
 


### PR DESCRIPTION
else it prevents to build on Linux as arduino.h
does not exist while Arduino.h exists.